### PR TITLE
fix: js和ts的loader都不需要编译项目根目录的node_modules

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -345,7 +345,7 @@ module.exports = class BuilderCore {
      * @private
      */
     static setJsRule() {
-        return {test: /\.js$/, loader: 'happypack/loader'};
+        return {test: /\.js$/, loader: 'happypack/loader', exclude: path.join(projectRoot, 'node_modules')};
     }
 
     /**
@@ -355,7 +355,7 @@ module.exports = class BuilderCore {
      * @private
      */
     static setTsRule() {
-        return {test: /\.ts(x?)$/, loader: 'happypack/loader'};
+        return {test: /\.ts(x?)$/, loader: 'happypack/loader', exclude: path.join(projectRoot, 'node_modules')};
     }
 
     /**


### PR DESCRIPTION
否则
1. 构建速度会慢
2. 有些库的开发依赖比如babel-loader不会安装装，会报错