### PR TITLE
feat: add image-webpack-loader

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -112,12 +112,31 @@ module.exports = class BuilderCore {
 
         return {
             test: /\.(png|svg|jpg|gif|blob)$/,
-            use: {
+            use: [{
                 loader: 'file-loader',
                 options: {
                     name: `${filename}img/[name]${hash}.[ext]`
                 }
-            }
+            },{
+                loader: 'image-webpack-loader',
+                options: {
+                    mozjpeg: {
+                      progressive: true,
+                      quality: 65
+                    },
+                    optipng: {
+                      enabled: true,
+                      optimizationLevel: 4,
+                    },
+                    pngquant: {
+                      quality: '65-90',
+                      speed: 4
+                    },
+                    gifsicle: {
+                      interlaced: false,
+                    },
+                }
+            }]
         };
     }
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "html-webpack-externals-plugin": "^3.6.0",
     "html-webpack-inline-source-plugin": "0.0.9",
     "html-webpack-plugin": "^2.30.1",
+    "image-webpack-loader": "^4.6.0",
     "less": "^3.8.0",
     "less-loader": "^4.1.0",
     "node-sass": "^4.9.0",


### PR DESCRIPTION
压缩图片，解决 sprite-loader 生成雪碧图后图片体积过大的问题。
![wechatworkscreenshot_4473a238-25c1-43af-a58a-ce078ca533c5](https://user-images.githubusercontent.com/21354661/53218663-f501ac80-3697-11e9-998d-d065edb7c0e4.png)
